### PR TITLE
Eahw 2207/fix routing

### DIFF
--- a/helm/config/default.conf.template
+++ b/helm/config/default.conf.template
@@ -127,7 +127,7 @@ server {
         proxy_intercept_errors on;
 
         # Comment out this line to receive the error messages returned by S3
-        #error_page 400 401 402 403 404 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 500 501 502 503 504 505 506 507 508 509 510 511 =404 @error404;
+        error_page 400 401 402 403 404 405 406 407 408 409 410 411 412 413 414 415 416 417 418 420 422 423 424 426 428 429 431 444 449 450 451 500 501 502 503 504 505 506 507 508 509 510 511 =404 @error404;
 
         proxy_pass ${S3_SERVER_PROTO}://storage_urls$uri_path;
     }

--- a/helm/config/default.conf.template
+++ b/helm/config/default.conf.template
@@ -11,9 +11,9 @@ include /etc/nginx/conf.d/gateway/v${AWS_SIGS_VERSION}_js_vars.conf;
 # Extracts only the path from the requested URI. This strips out all query
 # parameters and anchors in order to prevent extranous data from being sent to
 # S3.
-#map $request_uri $uri_path {
-#    "~^(?P<path>.*?)(\?.*)*$"  $path;
-#}
+map $request_uri $uri_path {
+    "~^(?P<path>.*?)(\?.*)*$"  $path;
+}
 
 map $S3_STYLE $s3_host_hdr {
     virtual "${S3_BUCKET_NAME}.${S3_SERVER}";

--- a/helm/config/default.conf.template
+++ b/helm/config/default.conf.template
@@ -81,7 +81,7 @@ server {
     }
 
     location / {
-        set $uri_path       "/$subenv/$branch$request_uri";
+        set $uri_path       "/$subenv/$branch$uri_path";        
         
         auth_request /aws/credentials/retrieve;
 

--- a/helm/config/default.conf.template
+++ b/helm/config/default.conf.template
@@ -47,7 +47,7 @@ server {
 
     # Uncomment this for a HTTP header that will let you know the cache status
     # of an object.
-    # add_header X-Cache-Status $upstream_cache_status;
+    add_header X-Cache-Status $upstream_cache_status;    
 
     # Proxy caching configuration. Customize this for your needs.
     proxy_cache s3_cache;

--- a/helm/config/nginx.conf
+++ b/helm/config/nginx.conf
@@ -33,7 +33,8 @@ http {
 
     log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
     '$status $body_bytes_sent "$http_referer" '
-    '"$http_user_agent" "$http_x_forwarded_for"';
+    '"$http_user_agent" "$http_x_forwarded_for" '
+    'upstream_status: $upstream_status uri_path: $uri_path';
 
     access_log  /var/log/nginx/access.log  main;
 


### PR DESCRIPTION
Currently querystring parameters are being passed from nginx to s3 e.g. https://bucketname.s3.region.amazonaws.com/my/path/silent-check-sso.html?state=asdf

but this is causing a 403 to be returned by the s3 request as querystring parameters aren't expected to be there by s3gateway.js (which is responsible for creating the AWS signature - https://docs.aws.amazon.com/general/latest/gr/signature-version-4.html)

To fix: re-enabled the querystring removal from uri_path

Also:

- Added a cache header so we can see what hits/misses the cache as caching is exacerbating the problem and hindering debugging (caching config tbc)
- Added the upstream HTTP status and uri_path to the nginx logs 
- Switched off the s3 errors from showing in the browser