### PR TITLE
Support notprod domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ When pushing to the Git repository the image will be built by Drone, and when ta
 The default implementation of the nginx s3 gateway reads the URI path (http://mywebsite.com/uripath/index.html) and constructs the request to the s3 bucket based on that (https://bucketname.s3.us-east.amazonaws.com/uripath/index.html). This implementation is slightly different in that it reads the path information from the URL (http://subenv.mywebsite.com) using a regular expression:
 ```
 map $host $subenv {
-    ~^[^.]+\.(?<p2>[^.]+)\.callisto.homeoffice.gov.uk$ $p2;
+    ~^[^.]+\.(?<p2>[^.]+)\.callisto(?:-notprod)?.homeoffice.gov.uk$ $p2;
 }
 ```
 In the future it will also read the branch (JIRA ticket number) in the same way (http://subenv.branch.mywebsite.com)

--- a/helm/config/default.conf.template
+++ b/helm/config/default.conf.template
@@ -20,11 +20,11 @@ map $S3_STYLE $s3_host_hdr {
 }
 
 map $host $branch {
-    ~^web.[^.]+.callisto.homeoffice.gov.uk$ "main";
+    ~^web.[^.]+.callisto(?:-notprod)?.homeoffice.gov.uk$ "main";
 }
 
 map $host $subenv {
-    ~^[^.]+\.(?<p2>[^.]+)\.callisto.homeoffice.gov.uk$ $p2;
+    ~^[^.]+\.(?<p2>[^.]+)\.callisto(?:-notprod)?.homeoffice.gov.uk$ $p2;
 }
 
 js_var $indexIsEmpty true;


### PR DESCRIPTION
Our UI nginx config performs regex matches against the host to extract info about the environment for constructing the s3 object path. We’re moving our non-prod services to the `callisto-notprod.homeoffice.gov.uk` domain.

The bit for extracting the `subenv` will need to support both domains indefinitely. The bit extracting the branch will only need to support the non ‘not-prod’ version until we’ve made the switch.