### PR TITLE
Eahw 2697/UI review fix routing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3.3'
+
+services:
+  callisto-ui-nginx:
+    image: ghcr.io/nginxinc/nginx-s3-gateway/nginx-oss-s3-gateway:latest-20220916
+    ports:
+      - "50002:3000"
+    environment:
+      - S3_ENV_DEFAULT=/dev
+      - S3_BUCKET_NAME=${S3_BUCKET_NAME}
+      - S3_ACCESS_KEY_ID=${S3_ACCESS_KEY_ID}
+      - S3_SECRET_KEY=${S3_SECRET_KEY}
+      - S3_SERVER=s3.eu-west-2.amazonaws.com
+      - S3_SERVER_PORT=443
+      - S3_SERVER_PROTO=https
+      - S3_REGION=eu-west-2
+      - S3_STYLE=virtual
+      - S3_DEBUG=true
+      - AWS_SIGS_VERSION=4
+      - ALLOW_DIRECTORY_LIST=false
+      - PROXY_CACHE_VALID_OK=1s
+      - PROXY_CACHE_VALID_NOTFOUND=1s
+      - PROXY_CACHE_VALID_FORBIDDEN=1s
+      - PROVIDE_INDEX_PAGE=true
+      - APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=false
+    volumes:
+      - ./helm/config/default.conf.template:/etc/nginx/templates/default.conf.template
+      - ./helm/config/nginx.conf:/etc/nginx/nginx.conf

--- a/helm/config/default.conf.template
+++ b/helm/config/default.conf.template
@@ -27,7 +27,7 @@ map $host $branch {
 
 map $host $subenv {
     ~^[^.]+\.(?<p2>[^.]+)\.callisto(?:-notprod)?.homeoffice.gov.uk$ "/$p2";     
-    default "";    
+    default "${S3_ENV_DEFAULT}";    
 }
 
 js_var $indexIsEmpty true;
@@ -81,8 +81,8 @@ server {
         return 200;
     }
 
-    location ~* "/(?!(assets/|silent-check-sso))" {
-        set $uri_path       "$subenv/$branch/"; 
+    location ~* ^/(?!(aws/|assets/|silent-check-sso|index.html$)) {
+        set $uri_path       "$subenv/$branch/index.html"; 
 
         auth_request /aws/credentials/retrieve;
 


### PR DESCRIPTION
The latest location wasn't specific enough so the call 
```auth_request /aws/credentials/retrieve;```
meant that it ended up in a recursive loop. 
the fix was to add the /aws/ prefix to the negative lookahead