### PR TITLE
Add S3_ENV_DEFAULT to deployment 

### DIFF
--- a/helm/templates/deployment.yml
+++ b/helm/templates/deployment.yml
@@ -78,6 +78,8 @@ spec:
               value: "{{ .Values.nginxs3proxy.provideIndexPage }}"
             - name: APPEND_SLASH_FOR_POSSIBLE_DIRECTORY
               value: "{{ .Values.nginxs3proxy.appendSlashForPossibleDirectory }}"
+            - name: S3_ENV_DEFAULT
+              value: ""
           resources:
             requests:
               memory: '512Mi'


### PR DESCRIPTION
An environment variable was introduced to make it easier to set the environment when running on localhost for debugging/development. This caused the error 'unknown "s3_env_default"… variable'.
Added the environment variable in the hope of preventing this.