### PR TITLE
Add another exception for a public/static folder in the react ui

### DIFF
--- a/helm/config/default.conf.template
+++ b/helm/config/default.conf.template
@@ -81,7 +81,7 @@ server {
         return 200;
     }
 
-    location ~* ^/(?!(aws/|assets/|silent-check-sso|index.html$)) {
+    location ~* ^/(?!(aws/|static/|assets/|silent-check-sso|index.html$)) {
         set $uri_path       "$subenv/$branch/index.html"; 
 
         auth_request /aws/credentials/retrieve;


### PR DESCRIPTION
We noticed that files outside of the react application (that are placed in the public folder) are no longer reachable due to the rules rewriting URLs to serve the index.html. As we can't accommodate all potential filenames we've introduce a single subfolder under the `public` folder called `static`. This results in all URLs starting with `static` e.g. `/static/emblem.jpg`. Then URLs starting `/static` can be excluded from the rewrite.